### PR TITLE
(#20725) adding rudimentary RedHat support

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,3 @@
-Provides a set of defined resource types for managing stunnel on Debain systems.
-Should be easily adaptable to EL platforms.  Example usage can be found in the
-test directory or module documentation.
+Provides a set of defined resource types for managing stunnel on Debian and
+RedHat systems.  Example usage can be found in the test directory or module
+documentation.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,35 +32,43 @@
 #
 # Copyright 2012 Puppet Labs, LLC
 #
-class stunnel(
-  $package  = $stunnel::data::package,
-  $service  = $stunnel::data::service,
-  $conf_dir = $stunnel::data::conf_dir
-) inherits stunnel::data {
+class stunnel (
+  $package  = $stunnel::params::package,
+  $service  = $stunnel::params::service,
+  $conf_dir = $stunnel::params::conf_dir,
+  $needs_exec = $stunnel::params::needs_exec,
+) inherits stunnel::params {
 
-  package { $package:
+  package { $stunnel::package:
     ensure => present,
   }
 
-  file { $conf_dir:
+  file { $stunnel::conf_dir:
     ensure  => directory,
-    require => Package[$package],
+    require => Package[$stunnel::package],
     purge   => true,
     recurse => true,
   }
 
-  exec { 'enable stunnel':
-    command => 'sed -i "s/ENABLED=0/ENABLED=1/" /etc/default/stunnel4',
-    path    => [ '/bin', '/usr/bin' ],
-    unless  => 'grep "ENABLED=1" /etc/default/stunnel4',
-    require => Package[$package],
-    before  => Service[$service],
+  if $stunnel::needs_exec {
+    exec { 'enable stunnel':
+      command => 'sed -i "s/ENABLED=0/ENABLED=1/" /etc/default/stunnel4',
+      path    => [ '/bin', '/usr/bin' ],
+      unless  => 'grep "ENABLED=1" /etc/default/stunnel4',
+      require => Package[$stunnel::package],
+    }
+
+    if $stunnel::service {
+      Exec['enable stunnel'] -> Service[$stunnel::service]
+    }
   }
 
-  service { $service:
-    ensure     => running,
-    enable     => true,
-    hasrestart => true,
-    hasstatus  => false,
+  if $stunnel::service {
+    service { $service:
+      ensure     => 'running',
+      enable     => true,
+      hasrestart => true,
+      hasstatus  => false,
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,4 @@
-# == Class: stunnel::data
+# == Class: stunnel::params
 #
 # This module sets up SSL encrypted and authenticated tunnels using the
 # common application stunnel.
@@ -24,8 +24,22 @@
 #
 # Copyright 2012 Puppet Labs, LLC
 #
-class stunnel::data {
-  $conf_dir = '/etc/stunnel'
-  $package  = 'stunnel4'
-  $service  = 'stunnel4'
+class stunnel::params {
+  case $::osfamily {
+    'Debian': {
+      $conf_dir   = '/etc/stunnel'
+      $package    = 'stunnel4'
+      $service    = 'stunnel4'
+      $needs_exec = true
+    }
+    'RedHat': {
+      $conf_dir   = '/etc/stunnel'
+      $package    = 'stunnel'
+      $service    = false
+      $needs_exec = true
+    }
+    default: {
+      fail("${::operatingsystem} platform not supported.")
+    }
+  }
 }


### PR DESCRIPTION
Installs package and creates config files; still no support for service
management.  Renamed stunnel::data to stunnel::params for style.
