### PR TITLE
More stunnel options and making some existing ones optional

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,0 +1,8 @@
+name    'puppetlabs-stunnel'
+version '0.0.1'
+source  'git@github.com:puppetlabs/puppetlabs-stunnel.git'
+author  'puppetlabs'
+license 'Apache License 2.0'
+summary 'Puppet Stunnel Module'
+description 'Provides a defined resource type for managing stunnel on Debian and Red Hat systems.'
+project_page 'https://github.com/puppetlabs/puppetlabs-stunnel'

--- a/README.md
+++ b/README.md
@@ -4,16 +4,21 @@ Provides a defined resource type for managing stunnel on Debian and Red Hat syst
 ## Usage
 ```
    stunnel::tun { 'rsyncd':
-     certificate => "/etc/puppet/ssl/certs/${::clientcert}.pem",
-     private_key => "/etc/puppet/ssl/private_keys/${::clientcert}.pem",
-     ca_file     => '/etc/puppet/ssl/certs/ca.pem',
-     crl_file    => '/etc/puppet/ssl/crl.pem',
-    chroot      => '/var/lib/stunnel4/rsyncd',
-     user        => 'pe-puppet',
-     group       => 'pe-puppet',
-     client      => false,
-     accept      => '1873',
-     connect     => '873',
+     certificate   => "/etc/puppet/ssl/certs/${::clientcert}.pem",
+     private_key   => "/etc/puppet/ssl/private_keys/${::clientcert}.pem",
+     ca_file       => '/etc/puppet/ssl/certs/ca.pem',
+     crl_file      => '/etc/puppet/ssl/crl.pem',
+     chroot        => '/var/lib/stunnel4/rsyncd',
+     user          => 'pe-puppet',
+     group         => 'pe-puppet',
+     client        => false,
+     accept        => '1873',
+     connect       => '873',
+    verify         => '2',
+    retry          => false,
+    foreground     => false,
+    ssl_options    => 'DONT_INSERT_EMPTY_FRAGMENTS',
+    socket_options => ['l:TCP_NODELAY=1','r:TCP_NODELAY=1'],
    }
 ```
 

--- a/manifests/tun.pp
+++ b/manifests/tun.pp
@@ -111,7 +111,8 @@ define stunnel::tun(
     $client,
     $accept,
     $connect,
-    $conf_dir    = $stunnel::params::conf_dir
+    $conf_dir    = $stunnel::params::conf_dir,
+    $verify      = 2,
 ) {
 
   $ssl_version_real = $ssl_version ? {
@@ -137,10 +138,13 @@ define stunnel::tun(
     require => File[$conf_dir],
   }
 
-  file { $chroot:
-    ensure => directory,
-    owner  => $user,
-    group  => $group,
-    mode   => '0600',
+  #it is possible that multiple stunnel tunnels may share the same chroot dir, therefore define it only if its not already defined
+  if (! defined( File[$chroot] )) {
+    file { $chroot:
+      ensure => directory,
+      owner  => $user,
+      group  => $group,
+      mode   => '0600',
+    }
   }
 }

--- a/manifests/tun.pp
+++ b/manifests/tun.pp
@@ -90,23 +90,27 @@
 # [*ssl_options*]
 #   OpenSSL library options
 #
+# [*socket_options*]
+#   Set an option on accept/local/remote socket, can be an array of options
+#
 # === Examples
 #
 #   stunnel::tun { 'rsyncd':
-#     certificate => "/etc/puppet/ssl/certs/${::clientcert}.pem",
-#     private_key => "/etc/puppet/ssl/private_keys/${::clientcert}.pem",
-#     ca_file     => '/etc/puppet/ssl/certs/ca.pem',
-#     crl_file    => '/etc/puppet/ssl/crl.pem',
-#     chroot      => '/var/lib/stunnel4/rsyncd',
-#     user        => 'pe-puppet',
-#     group       => 'pe-puppet',
-#     client      => false,
-#     accept      => '1873',
-#     connect     => '873',
-#     verify      => '2',
-#     retry       => false,
-#     foreground  => false,
-#     ssl_options => 'DONT_INSERT_EMPTY_FRAGMENTS',
+#     certificate    => "/etc/puppet/ssl/certs/${::clientcert}.pem",
+#     private_key    => "/etc/puppet/ssl/private_keys/${::clientcert}.pem",
+#     ca_file        => '/etc/puppet/ssl/certs/ca.pem',
+#     crl_file       => '/etc/puppet/ssl/crl.pem',
+#     chroot         => '/var/lib/stunnel4/rsyncd',
+#     user           => 'pe-puppet',
+#     group          => 'pe-puppet',
+#     client         => false,
+#     accept         => '1873',
+#     connect        => '873',
+#     verify         => '2',
+#     retry          => false,
+#     foreground     => false,
+#     ssl_options    => 'DONT_INSERT_EMPTY_FRAGMENTS',
+#     socket_options => ['l:TCP_NODELAY=1','r:TCP_NODELAY=1']
 #   }
 #
 # === Authors
@@ -123,21 +127,22 @@ define stunnel::tun(
     $private_key,
     $ca_file,
     $crl_file,
-    $ssl_version = 'TLSv1',
+    $ssl_version    = 'TLSv1',
     $chroot,
     $user,
     $group,
-    $pid_file    = "/${name}.pid",
-    $debug_level = '0',
-    $log_dest    = "/var/log/${name}.log",
+    $pid_file       = "/${name}.pid",
+    $debug_level    = '0',
+    $log_dest       = "/var/log/${name}.log",
     $client,
     $accept,
     $connect,
-    $conf_dir    = $stunnel::params::conf_dir,
-    $verify      = 2,
-    $retry       = false,
-    $foreground  = false,
-    $ssl_options = undef,
+    $conf_dir       = $stunnel::params::conf_dir,
+    $verify         = 2,
+    $retry          = false,
+    $foreground     = false,
+    $ssl_options    = undef,
+    $socket_options = ['l:TCP_NODELAY=1','r:TCP_NODELAY=1']
 ) {
 
   $ssl_version_real = $ssl_version ? {

--- a/manifests/tun.pp
+++ b/manifests/tun.pp
@@ -72,6 +72,24 @@
 #   By default we look this value up in a stunnel::data class, which has a
 #   list of common answers.
 #
+# [*verify*]
+# verify peer certificate, verify levels:
+#   0 - Request and ignore peer certificate.
+#   1 - Verify peer certificate if present.
+#   2 - Verify peer certificate.
+#   3 - Verify peer with locally installed certificate.
+#   4 - Ignore CA chain and only verify peer certificate.
+#   undef - no verify
+#
+# [*retry*]
+#   reconnect a connect+exec section after it's disconnected
+#
+# [*foreground*]
+#   Stay in foreground (don't fork) and log to stderr instead of via syslog (unless output is specified).
+#
+# [*ssl_options*]
+#   OpenSSL library options
+#
 # === Examples
 #
 #   stunnel::tun { 'rsyncd':
@@ -85,6 +103,10 @@
 #     client      => false,
 #     accept      => '1873',
 #     connect     => '873',
+#     verify      => '2',
+#     retry       => false,
+#     foreground  => false,
+#     ssl_options => 'DONT_INSERT_EMPTY_FRAGMENTS',
 #   }
 #
 # === Authors
@@ -113,6 +135,9 @@ define stunnel::tun(
     $connect,
     $conf_dir    = $stunnel::params::conf_dir,
     $verify      = 2,
+    $retry       = false,
+    $foreground  = false,
+    $ssl_options = undef,
 ) {
 
   $ssl_version_real = $ssl_version ? {
@@ -124,6 +149,16 @@ define stunnel::tun(
 
   $client_on = $client ? {
     true  => 'yes',
+    false => 'no',
+  }
+
+  $retry_on = $retry ? {
+    true => 'yes',
+    false => 'no',
+  }
+
+  $foreground_on = $foreground ? {
+    true => 'yes',
     false => 'no',
   }
 

--- a/templates/stunnel.conf.erb
+++ b/templates/stunnel.conf.erb
@@ -56,3 +56,4 @@ connect = <%= @connect %>
 <% if @retry_on -%>
 retry = <%= @retry_on %>
 <% end -%>
+

--- a/templates/stunnel.conf.erb
+++ b/templates/stunnel.conf.erb
@@ -1,5 +1,9 @@
 ; This stunnel config is managed by Puppet.
 
+<% if @foreground_on -%>
+foreground = <%= @foreground_on %>
+<% end -%>
+
 cert = <%= @certificate %>
 <% if @private_key -%>
 key = <%= @private_key %>
@@ -28,8 +32,10 @@ setgid = <%= @group %>
 pid = <%= @pid_file %>
 <% end -%>
 
-socket = l:TCP_NODELAY=1
-socket = r:TCP_NODELAY=1
+<% if @socket_options -%>
+<% [@socket_options].flatten.compact.each do |socket| %>socket = <%= socket %>
+<% end %>
+<% end -%>
 
 <% if @ssl_options -%>
 options = <%= @ssl_options %>
@@ -47,3 +53,6 @@ client = <%= @client_on %>
 [<%= name -%>]
 accept = <%= @accept %>
 connect = <%= @connect %>
+<% if @retry_on -%>
+retry = <%= @retry_on %>
+<% end -%>

--- a/templates/stunnel.conf.erb
+++ b/templates/stunnel.conf.erb
@@ -1,25 +1,25 @@
 ; This stunnel config is managed by Puppet.
 
-cert = <%= certificate %>
-key = <%= private_key %>
-CAfile = <%= ca_file %>
-CRLfile = <%= crl_file %>
-sslVersion = <%= ssl_version_real %>
+cert = <%= @certificate %>
+key = <%= @private_key %>
+CAfile = <%= @ca_file %>
+CRLfile = <%= @crl_file %>
+sslVersion = <%= @ssl_version_real %>
 verify = 2
 
-chroot = <%= chroot %>
-setuid = <%= user %>
-setgid = <%= group %>
-pid = <%= pid_file %>
+chroot = <%= @chroot %>
+setuid = <%= @user %>
+setgid = <%= @group %>
+pid = <%= @pid_file %>
 
 socket = l:TCP_NODELAY=1
 socket = r:TCP_NODELAY=1
 
-debug = <%= debug_level %>
-output = <%= log_dest %>
+debug = <%= @debug_level %>
+output = <%= @log_dest %>
 
-client = <%= client_on %>
+client = <%= @client_on %>
 
 [<%= name -%>]
-accept = <%= accept %>
-connect = <%= connect %>
+accept = <%= @accept %>
+connect = <%= @connect %>

--- a/templates/stunnel.conf.erb
+++ b/templates/stunnel.conf.erb
@@ -50,7 +50,7 @@ output = <%= @log_dest %>
 
 client = <%= @client_on %>
 
-[<%= name -%>]
+[<%= @name -%>]
 accept = <%= @accept %>
 connect = <%= @connect %>
 <% if @retry_on -%>

--- a/templates/stunnel.conf.erb
+++ b/templates/stunnel.conf.erb
@@ -11,7 +11,9 @@ CAfile = <%= @ca_file %>
 CRLfile = <%= @crl_file %>
 <% end -%>
 sslVersion = <%= @ssl_version_real %>
-verify = 2
+<% if @verify -%>
+verify = <%= @verify %>
+<% end -%>
 
 <% if @chroot -%>
 chroot = <%= @chroot %>
@@ -28,6 +30,10 @@ pid = <%= @pid_file %>
 
 socket = l:TCP_NODELAY=1
 socket = r:TCP_NODELAY=1
+
+<% if @ssl_options -%>
+options = <%= @ssl_options %>
+<% end -%>
 
 <% if @debug_level -%>
 debug = <%= @debug_level %>

--- a/templates/stunnel.conf.erb
+++ b/templates/stunnel.conf.erb
@@ -1,22 +1,40 @@
 ; This stunnel config is managed by Puppet.
 
 cert = <%= @certificate %>
+<% if @private_key -%>
 key = <%= @private_key %>
+<% end -%>
+<% if @ca_file -%>
 CAfile = <%= @ca_file %>
+<% end -%>
+<% if @crl_file -%>
 CRLfile = <%= @crl_file %>
+<% end -%>
 sslVersion = <%= @ssl_version_real %>
 verify = 2
 
+<% if @chroot -%>
 chroot = <%= @chroot %>
+<% end -%>
+<% if @user -%>
 setuid = <%= @user %>
+<% end -%>
+<% if @group -%>
 setgid = <%= @group %>
+<% end -%>
+<% if @pid_file -%>
 pid = <%= @pid_file %>
+<% end -%>
 
 socket = l:TCP_NODELAY=1
 socket = r:TCP_NODELAY=1
 
+<% if @debug_level -%>
 debug = <%= @debug_level %>
+<% end -%>
+<% if @log_dest -%>
 output = <%= @log_dest %>
+<% end -%>
 
 client = <%= @client_on %>
 


### PR DESCRIPTION
Added in more stunnel options into template and tuns.pp:
verify (no longer hard coded can be specified)
retry
foreground
ssl_options (options)
socket_options (socket is not longer hard coded)
Also changed template to only add some values if they are set as they are not needed in all cases