### PR TITLE
Add support for no certificate verify

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,2 @@
 require 'puppetlabs_spec_helper/rake_tasks'
+PuppetLint.configuration.send('disable_parameter_order')

--- a/manifests/tun.pp
+++ b/manifests/tun.pp
@@ -30,6 +30,15 @@
 #   certificate has not been revoked, you will need to load a revocation list.
 #   We default to the one distributed by Puppet Enterprise.
 #
+# [*verify*]
+#   Verify peer certificate. Default is 2 for backwards compatibility with
+#     this Puppet module.
+#   Other values: 1 - verify peer certificate if present
+#                 2 - verify peer certificate
+#                 3 - verify peer with locally installed certificate
+#                 default - no verify
+#   See below for examples.
+#
 # [*ssl_version*]
 #   Which SSL version you plan to enforce for this tunnel.  The preferred and
 #   default is TLSv1.
@@ -59,7 +68,7 @@
 #
 # [*client*]
 #   If we running our tunnel in client mode.  There is a difference in stunnel
-#   between initiating connections or listening for them.
+#   between initiating connections or listening for them.  Default: false.
 #
 # [*accept*]
 #   For which host and on which port to accept connection from.
@@ -74,11 +83,26 @@
 #
 # === Examples
 #
+#   Use a cert:
+#
 #   stunnel::tun { 'rsyncd':
 #     certificate => "/etc/puppet/ssl/certs/${::clientcert}.pem",
 #     private_key => "/etc/puppet/ssl/private_keys/${::clientcert}.pem",
 #     ca_file     => '/etc/puppet/ssl/certs/ca.pem',
 #     crl_file    => '/etc/puppet/ssl/crl.pem',
+#     verify      => '2',
+#     chroot      => '/var/lib/stunnel4/rsyncd',
+#     user        => 'pe-puppet',
+#     group       => 'pe-puppet',
+#     client      => false,
+#     accept      => '1873',
+#     connect     => '873',
+#   }
+#
+#   No cert:
+#
+#   stunnel::tun { 'rsyncd':
+#     verify      => 'default', # default means no verify, see man stunnel.
 #     chroot      => '/var/lib/stunnel4/rsyncd',
 #     user        => 'pe-puppet',
 #     group       => 'pe-puppet',
@@ -97,36 +121,39 @@
 # Copyright 2012 Puppet Labs, LLC
 #
 define stunnel::tun(
-    $certificate,
-    $private_key,
-    $ca_file,
-    $crl_file,
+    $certificate = undef,
+    $private_key = undef,
+    $ca_file     = undef,
+    $crl_file    = undef,
+    $ssl_version = 'TLSv1',
+    $verify      = '2',
     $chroot,
     $user,
     $group,
-    $client,
+    $client      = false,
     $accept,
     $connect,
-    $ssl_version = 'TLSv1',
     $pid_file    = "/${name}.pid",
     $debug_level = '0',
     $log_dest    = "/var/log/${name}.log",
     $conf_dir    = $stunnel::params::conf_dir
 ) {
 
-  $ssl_version_real = $ssl_version ? {
-    'tlsv1' => 'TLSv1',
-    'sslv2' => 'SSLv2',
-    'sslv3' => 'SSLv3',
-    default => $ssl_version,
+  unless $verify == 'default' {
+    $ssl_version_real = $ssl_version ? {
+      'tlsv1' => 'TLSv1',
+      'sslv2' => 'SSLv2',
+      'sslv3' => 'SSLv3',
+      default => $ssl_version,
+    }
+
+    validate_re($ssl_version_real, '^SSLv2$|^SSLv3$|^TLSv1$', 'The option ssl_version must have a value that is either SSLv2, SSLv3, of TLSv1. The default and prefered option is TLSv1. SSLv2 should be avoided.')
   }
 
   $client_on = $client ? {
     true  => 'yes',
     false => 'no',
   }
-
-  validate_re($ssl_version_real, '^SSLv2$|^SSLv3$|^TLSv1$', 'The option ssl_version must have a value that is either SSLv2, SSLv3, of TLSv1. The default and prefered option is TLSv1. SSLv2 should be avoided.')
 
   file { "${conf_dir}/${name}.conf":
     ensure  => file,

--- a/spec/defines/tun_spec.rb
+++ b/spec/defines/tun_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe 'stunnel::tun' do
+  context 'no verify' do
+    let(:pre_condition){ 'include stunnel' }
+    let(:title){ 'rsyncd' }
+    let(:params) do
+      {
+        'chroot'  => '/var/lib/stunnel4/rsyncd',
+        'user'    => 'pe-puppet',
+        'group'   => 'pe-puppet',
+        'client'  => true,
+        'accept'  => '1873',
+        'connect' => '873',
+        'verify'  => 'default',
+      }
+    end
+    it {
+      is_expected.to contain_file('/etc/stunnel/rsyncd.conf')
+        .with_content(/verify = default/)
+    }
+  end
+
+  context 'verify' do
+    let(:pre_condition){ 'include stunnel' }
+    let(:title){ 'rsyncd' }
+    let(:params) do
+      {
+        'certificate' => '/etc/puppet/ssl/certs/clientcert.pem',
+        'private_key' => '/etc/puppet/ssl/private_keys/clientcert.pem',
+        'ca_file'     => '/etc/puppet/ssl/certs/ca.pem',
+        'crl_file'    => '/etc/puppet/ssl/crl.pem',
+        'client'      => false,
+        'verify'      => '2',
+        'chroot'      => '/var/lib/stunnel4/rsyncd',
+        'user'        => 'pe-puppet',
+        'group'       => 'pe-puppet',
+        'accept'      => '1873',
+        'connect'     => '873',
+      }
+    end
+    it {
+      is_expected.to contain_file('/etc/stunnel/rsyncd.conf')
+        .with_content(/cert =.*verify = 2/m)
+    }
+  end
+end

--- a/templates/stunnel.conf.erb
+++ b/templates/stunnel.conf.erb
@@ -1,11 +1,16 @@
 ; This stunnel config is managed by Puppet.
 
+<% if @verify == 'default' -%>
+verify = default
+<% else -%>
 cert = <%= @certificate %>
 key = <%= @private_key %>
 CAfile = <%= @ca_file %>
 CRLfile = <%= @crl_file %>
 sslVersion = <%= @ssl_version_real %>
-verify = 2
+
+verify = <%= @verify %>
+<% end -%>
 
 chroot = <%= @chroot %>
 setuid = <%= @user %>


### PR DESCRIPTION
This adds support for not using certificate verification, see man
stunnel, section verify = default.

In addition, additional tests for the actual stunnel::tun defined type
are added, and tests to demonstrate backwards compatibility.