### PR TITLE
Fix support for no verify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,5 @@ matrix:
   - rvm: 2.1.5
     bundler_args: --without system_tests
     env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 1.9.3
-    bundler_args: --without system_tests
-    env: PUPPET_GEM_VERSION="~> 3.0"
 notifications:
   email: false

--- a/manifests/tun.pp
+++ b/manifests/tun.pp
@@ -33,10 +33,13 @@
 # [*verify*]
 #   Verify peer certificate. Default is 2 for backwards compatibility with
 #     this Puppet module.
-#   Other values: 1 - verify peer certificate if present
+#   Other values: 0 - request and ignore peer certificate.
+#                 1 - verify peer certificate if present
 #                 2 - verify peer certificate
 #                 3 - verify peer with locally installed certificate
+#                 4 - ignore CA chain and only verify peer certificate
 #                 default - no verify
+#   Note that this module has only been tested using verify mode 2 and default.
 #   See below for examples.
 #
 # [*ssl_version*]

--- a/spec/defines/tun_spec.rb
+++ b/spec/defines/tun_spec.rb
@@ -17,7 +17,7 @@ describe 'stunnel::tun' do
     end
     it {
       is_expected.to contain_file('/etc/stunnel/rsyncd.conf')
-        .with_content(/verify = default/)
+        .without_content(/verify/)
     }
   end
 

--- a/templates/stunnel.conf.erb
+++ b/templates/stunnel.conf.erb
@@ -1,8 +1,6 @@
 ; This stunnel config is managed by Puppet.
 
-<% if @verify == 'default' -%>
-verify = default
-<% else -%>
+<% unless @verify == 'default' -%>
 cert = <%= @certificate %>
 key = <%= @private_key %>
 CAfile = <%= @ca_file %>


### PR DESCRIPTION
On RHEL 7, which has Stunnel version 4.56, we found that a different
configuration was required.

Instead of specifying verify = default, it is in fact necessary to
simply not specify verify at all.

Without this patch applied, an error message is seen:

  "verify = default": Bad verify level

On RHEL 6, Stunnel version 4.29 is available and it behaves differently,
but it also allows verify to simply be not specified.

Therefore, this patch modifies templates/stunnel.conf.erb to simply not
add the verify line if verify level default is specified.